### PR TITLE
Add complex component pair

### DIFF
--- a/src/complex-component.tsx
+++ b/src/complex-component.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { resolveRefs, eventHandler } from "dbl-utils";
+
+import Goat from "./goat";
+import Component, { ComponentProps, ComponentState } from "./component";
+
+export interface ComplexComponentProps extends ComponentProps {
+  schema?: { view: any; definitions?: Record<string, any>; data?: any };
+  definitions?: Record<string, any>;
+  rules?: Record<string, any>;
+  childrenIn?: boolean;
+}
+
+export interface ComplexComponentState extends ComponentState {
+  view: any;
+}
+
+export const nameSuffixes = (sfxs: string[] = []): Record<string, any> => {
+  return sfxs.reduce<Record<string, any>>((acum, item) => {
+    acum[`$name${item}`] = ["join", ["$data/name", item], ""];
+    return acum;
+  }, {});
+};
+
+const schemaDefault = {
+  view: { name: "$nameDummy", content: "Remplazar esto" },
+  definitions: {},
+};
+
+export default class ComplexComponent<
+  TProps extends ComplexComponentProps = ComplexComponentProps,
+  TState extends ComplexComponentState = ComplexComponentState
+> extends Component<TProps, TState> {
+  static jsClass = "Complex";
+  static defaultProps: Partial<ComplexComponentProps> = {
+    ...Component.defaultProps,
+    schema: schemaDefault,
+    definitions: {},
+    classes: { ".": "" },
+    rules: {},
+  };
+
+  protected events: [string, (...args: any[]) => void][] = [];
+  protected goat: Goat;
+
+  constructor(props: TProps) {
+    super(props);
+    this.goat = new Goat(props, this.mutations.bind(this));
+    Object.assign(this.state, {
+      view: this.buildView(),
+    });
+  }
+
+  componentDidMount(): void {
+    this.events.forEach((e) => eventHandler.subscribe(...e));
+  }
+
+  componentWillUnmount(): void {
+    this.events.forEach(([eName]) => eventHandler.unsubscribe(eName));
+  }
+
+  buildView(): any {
+    const { schema = schemaDefault, rules, definitions, ...all } = this.props;
+    schema.data = all;
+    Object.assign(schema.definitions, definitions);
+    return resolveRefs(schema.view, schema, rules);
+  }
+
+  mutations(sn: string): any {
+    return (this.state as any)[sn];
+  }
+
+  content(children: React.ReactNode = this.props.children): React.ReactNode {
+    const { childrenIn } = this.props;
+    const content = this.goat.buildContent(this.state.view);
+    return (
+      <>
+        {content}
+        {!childrenIn && children}
+      </>
+    );
+  }
+}

--- a/src/complex-responsive-component.tsx
+++ b/src/complex-responsive-component.tsx
@@ -1,0 +1,68 @@
+import ResizeSensor from "css-element-queries/src/ResizeSensor";
+import { eventHandler } from "dbl-utils";
+
+import ComplexComponent, {
+  ComplexComponentProps,
+  ComplexComponentState,
+} from "./complex-component";
+
+export interface ComplexResponsiveComponentProps extends ComplexComponentProps {
+  breakpoints?: Record<string, number>;
+  onResize?: (size: { width: number; height: number }) => void;
+}
+
+export default class ComplexResponsiveComponent<
+  TProps extends ComplexResponsiveComponentProps = ComplexResponsiveComponentProps,
+  TState extends ComplexComponentState = ComplexComponentState
+> extends ComplexComponent<TProps, TState> {
+  static jsClass = "ComplexResponsive";
+  static defaultProps: Partial<ComplexResponsiveComponentProps> = {
+    ...ComplexComponent.defaultProps,
+    breakpoints: {
+      xs: 0,
+      sm: 576,
+      md: 768,
+      lg: 992,
+      xl: 1200,
+      xxl: 1400,
+    },
+  };
+
+  protected resizeSensor?: ResizeSensor;
+  protected onResizeTimeout?: NodeJS.Timeout;
+  protected breakpoint?: string;
+
+  componentDidMount(): void {
+    super.componentDidMount();
+    if (this.ref) this.resizeSensor = new ResizeSensor(this.ref.current!, this.onResize);
+    this.onResize();
+  }
+
+  componentWillUnmount(): void {
+    super.componentWillUnmount();
+    clearTimeout(this.onResizeTimeout);
+    this.resizeSensor?.detach();
+  }
+
+  onResize = (): void => {
+    clearTimeout(this.onResizeTimeout);
+    this.onResizeTimeout = setTimeout(() => {
+      if (!this.ref.current) return;
+      const { offsetWidth: width, offsetHeight: height } = this.ref.current;
+      if (typeof this.props.onResize === "function") {
+        this.props.onResize({ width, height });
+      }
+      this.breakpoint = Object.keys(this.props.breakpoints ?? {})
+        .filter((br) => width >= (this.props.breakpoints?.[br] ?? 0))
+        .pop();
+      eventHandler.dispatch(`resize.${this.props.name}`, {
+        width,
+        height,
+        breakpoint: this.breakpoint,
+      });
+      this.setState({
+        localClasses: [this.breakpoint, "animate"].flat().join(" "),
+      });
+    }, 200);
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ export { default as withRouteWrapper } from "./react-router-schema/with-route-wr
 export { default as appGoatCtrl } from "./app-controller";
 export { default as Component } from "./component";
 export { default as Goat } from "./goat";
+export { default as ComplexComponent } from "./complex-component";
+export { default as ComplexResponsiveComponent } from "./complex-responsive-component";
 
 export * from "./containers/container";
 export * from "./containers/details-container";
@@ -72,3 +74,5 @@ export * from "./components";
 export * from "./containers";
 export * from "./controllers";
 export * from "./goat";
+export * from "./complex-component";
+export * from "./complex-responsive-component";


### PR DESCRIPTION
## Summary
- add `ComplexComponent` based on dbl-components
- add `ComplexResponsiveComponent` with resize handling
- export complex components from package index

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686f243973448326bba1157077183b37

## Summary by Sourcery

Add ComplexComponent and ComplexResponsiveComponent to enable schema-driven rendering and responsive behavior, and make them available through the package entry point.

New Features:
- Add ComplexComponent for schema-based view rendering with dynamic data and definitions
- Add ComplexResponsiveComponent extending ComplexComponent with automatic resize detection, breakpoint handling, and resize event dispatch
- Export ComplexComponent and ComplexResponsiveComponent from the package index