### PR TITLE
Add GoatComponent

### DIFF
--- a/__tests__/goat-component.test.tsx
+++ b/__tests__/goat-component.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import GoatComponent from "../src/goat-component";
+
+const view = {
+  name: "hello",
+  component: "Component",
+  content: "Hola"
+};
+
+describe("GoatComponent", () => {
+  test("renders json based content", () => {
+    render(<GoatComponent name="gc" view={view} />);
+    expect(screen.getByText("Hola")).toBeInTheDocument();
+  });
+
+  test("renders children when childrenIn is false", () => {
+    const { container } = render(
+      <GoatComponent name="gc" view={view}>child</GoatComponent>
+    );
+    expect(container.innerHTML).toContain("child");
+  });
+});

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Component from "./component";
+import GoatComponent from "./goat-component";
 import containers from "./containers";
 import fields from "./fields";
 import mediaComponents from "./media";
@@ -9,6 +10,7 @@ import Route from "./react-router-schema/route";
 
 const COMPONENTS: Record<string, React.FC<any> | typeof React.Component<any, any>> = {
   Component,
+  GoatComponent,
   ...containers,
   ...fields,
   ...mediaComponents,

--- a/src/goat-component.tsx
+++ b/src/goat-component.tsx
@@ -1,0 +1,121 @@
+import React, { ReactNode } from "react";
+
+import eventHandler from "dbl-utils/event-handler";
+import { deepMerge } from "dbl-utils/object-mutation";
+import resolveRefs from "dbl-utils/resolve-refs";
+
+import Goat from "./goat";
+import Component, { ComponentProps, ComponentState } from "./component";
+
+export interface GoatComponentProps extends ComponentProps {
+  view?: any;
+  childrenIn?: boolean;
+  definitions?: Record<string, any>;
+  content?: string | any[] | object;
+  children?: ReactNode;
+}
+
+export interface GoatComponentState extends ComponentState {
+  [key: string]: any;
+}
+
+export interface TemplateSchema {
+  view: Record<string, any>;
+  definitions?: Record<string, any>;
+}
+
+export default class GoatComponent<
+  TProps extends GoatComponentProps = GoatComponentProps,
+  TState extends GoatComponentState = GoatComponentState
+> extends Component<TProps, TState> {
+  static jsClass = "GoatComponent";
+  static template?: TemplateSchema | null = {
+    view: {},
+    definitions: {}
+  };
+
+  static defaultProps: Partial<GoatComponentProps> = {
+    ...Component.defaultProps,
+    view: null,
+    childrenIn: false,
+    definitions: {}
+  };
+
+  protected events: [string, (...args: any[]) => void][] = [];
+  protected goat: Goat;
+  protected templateSolved: any;
+
+  constructor(props: TProps) {
+    super(props);
+    this.tag = "div";
+    Object.assign(this.state, {});
+    this.goat = new Goat(this.fixedProps, this.mutations.bind(this));
+    this.evalTemplate();
+  }
+
+  get fixedProps(): TProps {
+    return this.props;
+  }
+
+  get childrenIn(): string | boolean {
+    return this.props.childrenIn ?? false;
+  }
+
+  get theView(): any {
+    return (this.constructor as typeof GoatComponent).template?.view;
+  }
+
+  get theTemplate(): any {
+    return (this.constructor as typeof GoatComponent).template || {};
+  }
+
+  componentDidMount(): void {
+    this.events.forEach(([evtName, callback]) =>
+      eventHandler.subscribe(evtName, callback, this.name)
+    );
+    this.evalTemplate();
+  }
+
+  evalTemplate() {
+    const definitions = deepMerge(
+      this.theTemplate?.definitions || {},
+      this.props.definitions || {}
+    );
+
+    this.templateSolved = this.props.view
+      ? resolveRefs(this.props.view, {
+          template: this.theView,
+          definitions,
+          props: this.props,
+          state: this.state
+        })
+      : resolveRefs(this.theView, {
+          definitions,
+          props: this.props,
+          state: this.state
+        });
+  }
+
+  componentWillUnmount(): void {
+    this.events.forEach(([eName]) => eventHandler.unsubscribe(eName, this.name));
+  }
+
+  mutations(sectionName: string, section: any): any {
+    return (this.state as any)[sectionName];
+  }
+
+  content(children = this.props.children): any {
+    if (!this.templateSolved) return null;
+
+    const builded = this.goat.buildContent(this.templateSolved);
+    return !this.childrenIn ? (
+      <>
+        {builded}
+        {children}
+      </>
+    ) : (
+      builded
+    );
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export { default as withRouteWrapper } from "./react-router-schema/with-route-wr
 export { default as appCtrl } from "./app-controller";
 export { default as Component } from "./component";
 export { default as Goat } from "./goat";
+export { default as GoatComponent } from "./goat-component";
 export { default as ComplexComponent } from "./complex-component";
 export { default as ComplexResponsiveComponent } from "./complex-responsive-component";
 
@@ -66,5 +67,6 @@ export * from "./components";
 export * from "./containers";
 export * from "./controllers";
 export * from "./goat";
+export * from "./goat-component";
 export * from "./complex-component";
 export * from "./complex-responsive-component";


### PR DESCRIPTION
## Summary
- implement `GoatComponent` equivalent of JsonRenderComponent
- expose component in public API and component registry
- add unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686fcc45d48083269aa0e9577b088932

## Summary by Sourcery

Implement GoatComponent for JSON-driven rendering, integrate it into the public API and component registry, and add unit tests

New Features:
- Add GoatComponent class for dynamic JSON-based view rendering

Enhancements:
- Expose GoatComponent in the public exports and component registry

Tests:
- Add unit tests verifying GoatComponent content rendering and children behavior